### PR TITLE
Dont crawl external urls flag fix

### DIFF
--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -39,9 +39,8 @@ class ScanCommand extends Command
             ->addOption(
                 'dont-crawl-external-links',
                 'x',
-                InputOption::VALUE_REQUIRED,
-                'Crawl external links',
-                true
+                InputOption::VALUE_NONE,
+                'Dont crawl external links'
             );
     }
 
@@ -54,7 +53,7 @@ class ScanCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $baseUrl = $input->getArgument('url');
-        $crawlProfile = $input->getOption('dont-crawl-external-links') === 'false' ? new CrawlInternalUrls($baseUrl) : new CrawlAllUrls();
+        $crawlProfile = $input->getOption('dont-crawl-external-links') ? new CrawlInternalUrls($baseUrl) : new CrawlAllUrls();
 
         $output->writeln("Start scanning {$baseUrl}");
         $output->writeln('');

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -46,7 +46,7 @@ class ScanCommandTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_can_scan_only_internal_links()
     {
-        exec('php '.__DIR__."/../http-status-check scan http://localhost:8080 -x false > {$this->consoleLog}");
+        exec('php '.__DIR__."/../http-status-check scan http://localhost:8080 -x > {$this->consoleLog}");
 
         $this->appearsInConsoleOutput([
             'Start scanning http://localhost:8080',


### PR DESCRIPTION
There is a logic error with option `dont-crawl-external-links` on [this line](https://github.com/spatie/http-status-check/blob/master/src/ScanCommand.php#L57). When `dont-crawl-external-links` is `false` then it crawl internal urls. Should be When `dont-crawl-external-links` is `true` then crawl only internal urls. I removed required value from option and fix logic.