### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\HttpStatusCheck\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ScanCommandTest extends PHPUnit_Framework_TestCase
+class ScanCommandTest extends TestCase
 {
     /** @var string */
     protected $consoleLog;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).