### PR TITLE
bump version number to 3.1.1

### DIFF
--- a/src/ConsoleApplication.php
+++ b/src/ConsoleApplication.php
@@ -10,7 +10,7 @@ class ConsoleApplication extends Application
     {
         error_reporting(-1);
 
-        parent::__construct('Http status check', '2.3.0');
+        parent::__construct('Http status check', '3.1.1');
 
         $this->add(new ScanCommand());
     }


### PR DESCRIPTION
Currently it still echos "2.3.0", although the current version is "3.1.1".
~~~
$ http-status-check -V
Http status check 2.3.0 by Spatie
~~~