### PR TITLE
use response status code if available

### DIFF
--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -141,7 +141,9 @@ class CrawlLogger extends CrawlObserver
         RequestException $requestException,
         ?UriInterface $foundOnUrl = null
     ) {
-        $statusCode = self::UNRESPONSIVE_HOST;
+        $statusCode = $requestException->getResponse()
+            ? $requestException->getResponse()->getStatusCode()
+            : self::UNRESPONSIVE_HOST;
 
         $reason = $requestException->getResponse()
             ? $requestException->getResponse()->getReasonPhrase()


### PR DESCRIPTION
Adds status code to failed response output.

Before: (Host did not respond)
```
200 OK - https://xxx.co.uk/test.html
301 Moved Permanently - https://xxx.co.uk/test2-old.html
301 Moved Permanently - http://xxx.co.uk/test2.html
200 OK - https://xxx.co.uk/test2.html
Host did not respond: Not Found - https://xxx.co.uk/test3.html (found on https://xxx.co.uk/test2.html)

Crawling summary
----------------
1 url(s) did have unresponsive host(s)
Crawled 2 url(s) with statuscode 200
Crawled 2 url(s) with statuscode 301
```

After: (404)

```
200 OK - https://xxx.co.uk/test.html
301 Moved Permanently - https://xxx.co.uk/test2-old.html
301 Moved Permanently - http://xxx.co.uk/test2.html
200 OK - https://xxx.co.uk/test2.html
404: Not Found - https://xxx.co.uk/test3.html (found on https://xxx.co.uk/test2.html)

Crawling summary
----------------
Crawled 2 url(s) with statuscode 200
Crawled 2 url(s) with statuscode 301
Crawled 1 url(s) with statuscode 404
```
