### PR TITLE
follow and log redirects as multiple responses

### DIFF
--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -117,9 +117,38 @@ class CrawlLogger extends CrawlObserver
         ResponseInterface $response,
         ?UriInterface $foundOnUrl = null
     ) {
-        $statusCode = $response->getStatusCode();
-        $reason = $response->getReasonPhrase();
-        $this->addResult((String)$url,(string)$foundOnUrl,$statusCode,$reason);
+        // https://github.com/guzzle/guzzle/blob/master/docs/faq.rst#how-can-i-track-redirected-requests
+        if($response->getHeader('X-Guzzle-Redirect-History')){
+            // Retrieve both Redirect History headers
+            $fullRedirectReport = [];
+            // Retrieve both Redirect History headers
+            $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirect URI history
+            $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirect HTTP Status history
+            // Add the initial URI requested to the (beginning of) URI history
+            array_unshift($redirectUriHistory, (string)$url);
+            // Add the final HTTP status code to the end of HTTP response history
+            array_push($redirectCodeHistory, $response->getStatusCode());
+            $fullRedirectReport = [];
+            foreach ($redirectUriHistory as $key => $value) {
+                $fullRedirectReport[$key] = ['location' => $value, 'code' => $redirectCodeHistory[$key]];
+            }
+
+            foreach($fullRedirectReport as $k=>$redirect){
+                $this->addResult(
+                    (String)$redirect['location'],
+                    (string)$foundOnUrl,
+                    $redirect['code'],
+                    ''
+                );
+            }
+        }else{
+            $this->addResult(
+                (String)$url,
+                (string)$foundOnUrl,
+                $response->getStatusCode(),
+                ''
+            );
+        }
     }
 
     public function crawlFailed(

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -118,8 +118,7 @@ class CrawlLogger extends CrawlObserver
         ResponseInterface $response,
         ?UriInterface $foundOnUrl = null
     ) {
-
-        if($this->addRedirectedResult($url, $response, $foundOnUrl)){
+        if ($this->addRedirectedResult($url, $response, $foundOnUrl)) {
             return;
         }
 
@@ -180,9 +179,9 @@ class CrawlLogger extends CrawlObserver
         UriInterface $url,
         ResponseInterface $response,
         ?UriInterface $foundOnUrl = null
-    ){
+    ) {
         // if its not a redirect the return false
-        if (!$response->getHeader('X-Guzzle-Redirect-History')) {
+        if (! $response->getHeader('X-Guzzle-Redirect-History')) {
             return false;
         }
 
@@ -216,5 +215,4 @@ class CrawlLogger extends CrawlObserver
 
         return true;
     }
-
 }

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CrawlLogger extends CrawlObserver
 {
     const UNRESPONSIVE_HOST = 'Host did not respond';
+    const REDIRECT = 'Redirect';
 
     /**
      * @var \Symfony\Component\Console\Output\OutputInterface
@@ -138,7 +139,7 @@ class CrawlLogger extends CrawlObserver
                     (string) $redirect['location'],
                     (string) $foundOnUrl,
                     $redirect['code'],
-                    $response->getReasonPhrase()
+                    $k+1==count($fullRedirectReport) ? $response->getReasonPhrase() : self::REDIRECT
                 );
             }
         } else {
@@ -165,6 +166,12 @@ class CrawlLogger extends CrawlObserver
 
     public function addResult($url, $foundOnUrl, $statusCode, $reason)
     {
+        // done display duplicate results
+        // this happens if a redirect if a redirect is followed to a page
+        if( isset($this->crawledUrls[$statusCode]) && in_array($url, $this->crawledUrls[$statusCode]) ){
+            return;
+        }
+
         $colorTag = $this->getColorTagForStatusCode($statusCode);
 
         $timestamp = date('Y-m-d H:i:s');

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -118,14 +118,14 @@ class CrawlLogger extends CrawlObserver
         ?UriInterface $foundOnUrl = null
     ) {
         // https://github.com/guzzle/guzzle/blob/master/docs/faq.rst#how-can-i-track-redirected-requests
-        if($response->getHeader('X-Guzzle-Redirect-History')){
+        if ($response->getHeader('X-Guzzle-Redirect-History')) {
             // Retrieve both Redirect History headers
             $fullRedirectReport = [];
             // Retrieve both Redirect History headers
             $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History'); // retrieve Redirect URI history
             $redirectCodeHistory = $response->getHeader('X-Guzzle-Redirect-Status-History'); // retrieve Redirect HTTP Status history
             // Add the initial URI requested to the (beginning of) URI history
-            array_unshift($redirectUriHistory, (string)$url);
+            array_unshift($redirectUriHistory, (string) $url);
             // Add the final HTTP status code to the end of HTTP response history
             array_push($redirectCodeHistory, $response->getStatusCode());
             $fullRedirectReport = [];
@@ -133,18 +133,18 @@ class CrawlLogger extends CrawlObserver
                 $fullRedirectReport[$key] = ['location' => $value, 'code' => $redirectCodeHistory[$key]];
             }
 
-            foreach($fullRedirectReport as $k=>$redirect){
+            foreach ($fullRedirectReport as $k=>$redirect) {
                 $this->addResult(
-                    (String)$redirect['location'],
-                    (string)$foundOnUrl,
+                    (string) $redirect['location'],
+                    (string) $foundOnUrl,
                     $redirect['code'],
                     $response->getReasonPhrase()
                 );
             }
-        }else{
+        } else {
             $this->addResult(
-                (String)$url,
-                (string)$foundOnUrl,
+                (string) $url,
+                (string) $foundOnUrl,
                 $response->getStatusCode(),
                 $response->getReasonPhrase()
             );
@@ -156,14 +156,15 @@ class CrawlLogger extends CrawlObserver
         RequestException $requestException,
         ?UriInterface $foundOnUrl = null
     ) {
-        if( $response=$requestException->getResponse() ){
-            $this->crawled($url,$response,$foundOnUrl);
-        }else{
-            $this->addResult((String)$url,(string)$foundOnUrl,'---',self::UNRESPONSIVE_HOST);
+        if ($response = $requestException->getResponse()) {
+            $this->crawled($url, $response, $foundOnUrl);
+        } else {
+            $this->addResult((string) $url, (string) $foundOnUrl, '---', self::UNRESPONSIVE_HOST);
         }
     }
 
-    public function addResult($url, $foundOnUrl, $statusCode, $reason){
+    public function addResult($url, $foundOnUrl, $statusCode, $reason)
+    {
         $colorTag = $this->getColorTagForStatusCode($statusCode);
 
         $timestamp = date('Y-m-d H:i:s');

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -139,7 +139,7 @@ class CrawlLogger extends CrawlObserver
                     (string) $redirect['location'],
                     (string) $foundOnUrl,
                     $redirect['code'],
-                    $k+1==count($fullRedirectReport) ? $response->getReasonPhrase() : self::REDIRECT
+                    $k + 1 == count($fullRedirectReport) ? $response->getReasonPhrase() : self::REDIRECT
                 );
             }
         } else {
@@ -168,7 +168,7 @@ class CrawlLogger extends CrawlObserver
     {
         // done display duplicate results
         // this happens if a redirect if a redirect is followed to a page
-        if( isset($this->crawledUrls[$statusCode]) && in_array($url, $this->crawledUrls[$statusCode]) ){
+        if (isset($this->crawledUrls[$statusCode]) && in_array($url, $this->crawledUrls[$statusCode])) {
             return;
         }
 

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -138,7 +138,7 @@ class CrawlLogger extends CrawlObserver
                     (String)$redirect['location'],
                     (string)$foundOnUrl,
                     $redirect['code'],
-                    ''
+                    $response->getReasonPhrase()
                 );
             }
         }else{
@@ -146,7 +146,7 @@ class CrawlLogger extends CrawlObserver
                 (String)$url,
                 (string)$foundOnUrl,
                 $response->getStatusCode(),
-                ''
+                $response->getReasonPhrase()
             );
         }
     }
@@ -170,7 +170,7 @@ class CrawlLogger extends CrawlObserver
 
         $message = "{$statusCode} {$reason} - ".(string) $url;
 
-        if ($foundOnUrl) {
+        if ($foundOnUrl && $colorTag === 'error') {
             $message .= " (found on {$foundOnUrl})";
         }
 

--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -119,7 +119,9 @@ class ScanCommand extends Command
         $clientOptions = [
             RequestOptions::TIMEOUT => $input->getOption('timeout'),
             RequestOptions::VERIFY => ! $input->getOption('skip-verification'),
-            RequestOptions::ALLOW_REDIRECTS => false,
+            RequestOptions::ALLOW_REDIRECTS => [
+                'track_redirects' => true,
+            ],
         ];
 
         $clientOptions = array_merge($clientOptions, $input->getOption('options'));

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -42,8 +42,8 @@ class ScanCommandTest extends TestCase
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
             'Crawling summary',
             'Crawled 5 url(s) with statuscode 200',
-            'Crawled 1 url(s) with statuscode 302',
-            'Crawled 1 url(s) with statuscode 404',
+            'Crawled 2 url(s) with statuscode 302',
+            'Crawled 2 url(s) with statuscode 404',
         ]);
     }
 
@@ -62,8 +62,8 @@ class ScanCommandTest extends TestCase
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
             'Crawling summary',
             'Crawled 4 url(s) with statuscode 200',
-            'Crawled 1 url(s) with statuscode 302',
-            'Crawled 1 url(s) with statuscode 404',
+            'Crawled 2 url(s) with statuscode 302',
+            'Crawled 2 url(s) with statuscode 404',
         ]);
     }
 

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -78,7 +78,6 @@ class ScanCommandTest extends TestCase
         ]);
     }
 
-
     /** @test */
     public function it_can_write_urls_with_errors_to_an_output_file()
     {

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -42,8 +42,8 @@ class ScanCommandTest extends TestCase
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
             'Crawling summary',
             'Crawled 5 url(s) with statuscode 200',
-            'Crawled 2 url(s) with statuscode 302',
-            'Crawled 2 url(s) with statuscode 404',
+            'Crawled 1 url(s) with statuscode 302',
+            'Crawled 1 url(s) with statuscode 404',
         ]);
     }
 
@@ -62,10 +62,22 @@ class ScanCommandTest extends TestCase
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
             'Crawling summary',
             'Crawled 4 url(s) with statuscode 200',
-            'Crawled 2 url(s) with statuscode 302',
-            'Crawled 2 url(s) with statuscode 404',
+            'Crawled 1 url(s) with statuscode 302',
+            'Crawled 1 url(s) with statuscode 404',
         ]);
     }
+
+    /** @test */
+    public function it_can_follow_redirect_to_not_found()
+    {
+        exec('php '.__DIR__."/../http-status-check scan http://localhost:8080/redirectToNotFound > {$this->consoleLog}");
+
+        $this->appearsInConsoleOutput([
+            'Crawled 1 url(s) with statuscode 302',
+            'Crawled 1 url(s) with statuscode 404',
+        ]);
+    }
+
 
     /** @test */
     public function it_can_write_urls_with_errors_to_an_output_file()

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -102,7 +102,7 @@ class ScanCommandTest extends TestCase
         foreach ($texts as $text) {
             $consoleLogContent = file_get_contents($this->consoleLog);
 
-            $this->assertGreaterThan(0, substr_count($consoleLogContent, $text), "Did not find `{$text}` in the log: {$consoleLogContent}");
+            $this->assertEquals(1, substr_count($consoleLogContent, $text.PHP_EOL), "Did not find `{$text}` in the log");
         }
     }
 

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -36,7 +36,7 @@ class ScanCommandTest extends TestCase
             '200 OK - http://localhost:8080/',
             '200 OK - http://localhost:8080/link1',
             '200 OK - http://localhost:8080/link2',
-            '302 Found - http://localhost:8080/link4',
+            '302 Redirect - http://localhost:8080/link4',
             '200 OK - http://example.com/',
             '200 OK - http://localhost:8080/link3',
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
@@ -57,7 +57,7 @@ class ScanCommandTest extends TestCase
             '200 OK - http://localhost:8080/',
             '200 OK - http://localhost:8080/link1',
             '200 OK - http://localhost:8080/link2',
-            '302 Found - http://localhost:8080/link4',
+            '302 Redirect - http://localhost:8080/link4',
             '200 OK - http://localhost:8080/link3',
             'Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)',
             'Crawling summary',
@@ -102,7 +102,7 @@ class ScanCommandTest extends TestCase
         foreach ($texts as $text) {
             $consoleLogContent = file_get_contents($this->consoleLog);
 
-            $this->assertEquals(1, substr_count($consoleLogContent, $text), "Did not find `{$text}` in the log {$consoleLogContent}");
+            $this->assertGreaterThan(0, substr_count($consoleLogContent, $text), "Did not find `{$text}` in the log: {$consoleLogContent}");
         }
     }
 

--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -102,7 +102,7 @@ class ScanCommandTest extends TestCase
         foreach ($texts as $text) {
             $consoleLogContent = file_get_contents($this->consoleLog);
 
-            $this->assertEquals(1, substr_count($consoleLogContent, $text.PHP_EOL), "Did not find `{$text}` in the log");
+            $this->assertEquals(1, substr_count($consoleLogContent, $text), "Did not find `{$text}` in the log {$consoleLogContent}");
         }
     }
 

--- a/tests/fixtures/output.txt
+++ b/tests/fixtures/output.txt
@@ -1,1 +1,1 @@
-404: Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)
+404 Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)

--- a/tests/fixtures/overwrite.txt
+++ b/tests/fixtures/overwrite.txt
@@ -1,1 +1,1 @@
-404: Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)
+404 Not Found - http://localhost:8080/notExists (found on http://localhost:8080/link3)

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -3,7 +3,7 @@
 let app = require('express')();
 
 app.get('/', function (request, response) {
-    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="/link4">Link4</a><a href="mailto:test@example.com">Email</a>');
+    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="/link4">Link4</a><a href="/link5">Link5</a><a href="mailto:test@example.com">Email</a>');
 });
 
 app.get('/link1', function (request, response) {
@@ -20,6 +20,10 @@ app.get('/link3', function (request, response) {
 
 app.get('/link4', function (request, response) {
     response.redirect('/link1');
+});
+
+app.get('/link5', function (request, response) {
+    response.redirect('/notExists2');
 });
 
 let server = app.listen(8080, function () {

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -3,7 +3,7 @@
 let app = require('express')();
 
 app.get('/', function (request, response) {
-    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="/link4">Link4</a><a href="/link5">Link5</a><a href="mailto:test@example.com">Email</a>');
+    response.end('<a href="/link1">Link1</a><a href="/link2">Link2</a><a href="/link4">Link4</a><a href="mailto:test@example.com">Email</a>');
 });
 
 app.get('/link1', function (request, response) {
@@ -22,7 +22,7 @@ app.get('/link4', function (request, response) {
     response.redirect('/link1');
 });
 
-app.get('/link5', function (request, response) {
+app.get('/redirectToNotFound', function (request, response) {
     response.redirect('/notExists2');
 });
 


### PR DESCRIPTION
Fixes #62

## Changes

* Adds a new url to the the test server (/redirectToNotFound) that will redirect (302) to a 404.
* Adds a test to assert that a 302 and 404 is found when crawling /redirectToNotFound
* Enable `RequestOptions::ALLOW_REDIRECTS`
* Refactor the observer to log redirects as multiple results with respective codes
https://github.com/guzzle/guzzle/blob/master/docs/faq.rst#how-can-i-track-redirected-requests 

NOTE: Output formats, codes, responses etc may have changed slightly, potentually breaking any projects parsing the outputs.

## Background

Previously guzzle was set to **not** follow redirects. This results in the potential for parts of a site to be uncrawlable if they are behind a 301 or 302 redirect, and not linked internally anywhere else with a non-redirecting link.

Some webservers include a \<a href="destination"> link on the 301/302 body and this will mitigate the problem (spaite follows and indexes), however if the webserver does not do this, then the link won't be followed to its true destination, and the destination won't be indexed.

This is most obvious with a redirect to a not found page: You'd expect to see a 404 here:

```plain
./http-status-check scan http://localhost:8080/redirectToNotFound

Start scanning http://localhost:8080/redirectToNotFound

[2020-02-22 12:07:22] 302 Found - http://localhost:8080/redirectToNotFound

Crawling summary
----------------
Crawled 1 url(s) with statuscode 302
```

If I enable `RequestOptions::ALLOW_REDIRECTS` as suggested here https://github.com/spatie/crawler/issues/263 I get:

```plain
$ ./http-status-check scan http://localhost:8080/redirectToNotFound

Start scanning http://localhost:8080/redirectToNotFound

[2020-02-22 12:13:53] 404: Not Found - http://localhost:8080/redirectToNotFound

Crawling summary
----------------
Crawled 1 url(s) with statuscode 404
```

This looks better, we can see the 404 now, however on closer inspection you'll notice there are no 302's being shown. And the /redirectToNotFound is actually showing as a 404 where the real response was 302, the 404 should be associated with the /notExists2 URL that is still missing from the results. 

Now with this PR we see:

```plain
$ ./http-status-check scan http://localhost:8080/redirectToNotFound

Start scanning http://localhost:8080/redirectToNotFound

[2020-02-28 11:27:45] 302 Redirect - http://localhost:8080/redirectToNotFound
[2020-02-28 11:27:45] 404 Not Found - http://localhost:8080/notExists2

Crawling summary
----------------
Crawled 1 url(s) with statuscode 302
Crawled 1 url(s) with statuscode 404
```