### PR TITLE
Fix failing test on GitHub Actions after added php 8 support #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To run the tests, first make sure you have [Node.js](https://nodejs.org/) instal
 
 ```bash
 cd tests/server
-./start_server.sh
+npm install
+node server.js
 ```
 
 With the server running, you can start testing:

--- a/tests/server/server.js
+++ b/tests/server/server.js
@@ -7,7 +7,7 @@ app.get('/', function (request, response) {
 });
 
 app.get('/link1', function (request, response) {
-    response.end('You are on link1<a href="http://example.com/"</a>');
+    response.end('You are on link1<a href="http://example.com/">Example.com</a>');
 });
 
 app.get('/link2', function (request, response) {


### PR DESCRIPTION
* I've fixed the bug in server.js which caused the test it_can_scan_a_site to fail 
* I've updated the README with the correct text to start the node webserver in order to test this package 

The test is working now although the prefer-lowest php 8 job fails at this moment, i'm not quite sure how to best fix this.
Probably the minimum composer dependancies of guzzlehttp/guzzle and symfony/dom-crawler must be updated in the spatie/crawler package to the versions bellow in order to support php 8:
guzzlehttp/guzzle: 7.2
symfony/dom-crawler: 5.2