### PR TITLE
Improve PHPUnit fixture

### DIFF
--- a/tests/ScanCommandTest.php
+++ b/tests/ScanCommandTest.php
@@ -15,7 +15,7 @@ class ScanCommandTest extends TestCase
     /** @var string */
     protected $outputFile;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
According to the official [PHPunit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.