### PR TITLE
Update spatie/http-status-check

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4, 7.3]
+                php: [8.2, 8.1]
                 stability: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `spatie/http-status-check` will be documented in this file.
 
+## 4.0 - 2023-06-14
+
+- Remove support for PHP 8.0
+- Update spatie/crawler
+- Bump dependencies
+- Fix deprecation notices related to spatie/crawler
+
 ## 3.3.0 - 2020-12-01
 
 - Add support for PHP 8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[<img src="https://github-ads.s3.eu-central-1.amazonaws.com/support-ukraine.svg?t=1" />](https://supportukrainenow.org)
-
 # Check the HTTP status code of all links on a website
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/http-status-check.svg?style=flat-square)](https://packagist.org/packages/spatie/http-status-check)

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
-        "symfony/console": "^4.0|^5.0",
-        "spatie/crawler": "^4.7",
-        "guzzlehttp/promises": "^1.4"
+        "php": "^8.1",
+        "symfony/console": "^5.4|^6.0",
+        "spatie/crawler": "^8.0",
+        "guzzlehttp/promises": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^9.5.10"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/CrawlLogger.php
+++ b/src/CrawlLogger.php
@@ -5,7 +5,7 @@ namespace Spatie\HttpStatusCheck;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
-use Spatie\Crawler\CrawlObserver;
+use Spatie\Crawler\CrawlObservers\CrawlObserver;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CrawlLogger extends CrawlObserver
@@ -38,17 +38,15 @@ class CrawlLogger extends CrawlObserver
 
     /**
      * Called when the crawl will crawl the url.
-     *
-     * @param \Psr\Http\Message\UriInterface $url
      */
-    public function willCrawl(UriInterface $url)
+    public function willCrawl(UriInterface $url, ?string $linkText): void
     {
     }
 
     /**
      * Called when the crawl has ended.
      */
-    public function finishedCrawling()
+    public function finishedCrawling(): void
     {
         $this->consoleOutput->writeln('');
         $this->consoleOutput->writeln('Crawling summary');
@@ -116,8 +114,9 @@ class CrawlLogger extends CrawlObserver
     public function crawled(
         UriInterface $url,
         ResponseInterface $response,
-        ?UriInterface $foundOnUrl = null
-    ) {
+        ?UriInterface $foundOnUrl = null,
+        ?string $linkText = null,
+    ): void {
         if ($this->addRedirectedResult($url, $response, $foundOnUrl)) {
             return;
         }
@@ -134,8 +133,9 @@ class CrawlLogger extends CrawlObserver
     public function crawlFailed(
         UriInterface $url,
         RequestException $requestException,
-        ?UriInterface $foundOnUrl = null
-    ) {
+        ?UriInterface $foundOnUrl = null,
+        ?string $linkText = null,
+    ): void {
         if ($response = $requestException->getResponse()) {
             $this->crawled($url, $response, $foundOnUrl);
         } else {

--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -3,9 +3,9 @@
 namespace Spatie\HttpStatusCheck;
 
 use GuzzleHttp\RequestOptions;
-use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
-use Spatie\Crawler\CrawlProfiles\CrawlAllUrls;
 use Spatie\Crawler\Crawler;
+use Spatie\Crawler\CrawlProfiles\CrawlAllUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/ScanCommand.php
+++ b/src/ScanCommand.php
@@ -3,9 +3,9 @@
 namespace Spatie\HttpStatusCheck;
 
 use GuzzleHttp\RequestOptions;
-use Spatie\Crawler\CrawlAllUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlInternalUrls;
+use Spatie\Crawler\CrawlProfiles\CrawlAllUrls;
 use Spatie\Crawler\Crawler;
-use Spatie\Crawler\CrawlInternalUrls;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
- Remove support for PHP 8.0
- Update spatie/crawler
- Bump dependencies
- Fix deprecation notices related to spatie/crawler

Quite a big version bump, sorry 🙂 